### PR TITLE
include backslash in autocomplete suggestion

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -8,7 +8,7 @@ module.exports =
 
   completions: {}
 
-  texPattern: /\\([\w\d^-]*)$/
+  texPattern: /(\\[\w\d^-]*)$/
 
   load: (p) ->
     @selector = atom.config.get("latex-completions.selector")
@@ -17,7 +17,7 @@ module.exports =
     fs.readFile p, (error, content) =>
       return if error?
       for name, char of JSON.parse(content)
-        @completions[name] = char
+        @completions["\\" + name] = char
 
   getSuggestions: ({bufferPosition, editor}) ->
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])


### PR DESCRIPTION
this fixes the shadowing problem we'd have if there's another autocompletion provider that e.g. proivdes `beta`, while we want to complete `\beta`.

Compare this (before)
![before](https://cloud.githubusercontent.com/assets/6735977/12034000/f41e0294-ae2a-11e5-9d4d-4393024dca0e.PNG)
to this (after):
![after](https://cloud.githubusercontent.com/assets/6735977/12033994/c926e1c8-ae2a-11e5-91a5-0a4eb7183098.PNG)

This makes the list of autocomplete suggestions way longer, but I'm not sure whether that's a bad thing.
