### PR TITLE
Exclude lower priority

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -4,7 +4,7 @@ path = require 'path'
 module.exports =
   selector: '.source, .text'
   filterSuggestions: true
-  inclusionPriority: 5
+  suggestionPriority: 5
 
   completions: {}
 


### PR DESCRIPTION
In theory the higher priority of latex-completions should put it above julia-client completions, but that doesn't seem to be happening, so I'm just excluding julia-client's provider completely while latex-completions is active.

This kills a few of birds with one stone, including the shadowing problem of #4 and the problem of having to scroll down to find latex completions. cc @Varanas
