### PR TITLE
Add inclusion priority

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -5,6 +5,7 @@ module.exports =
   selector: '.source, .text'
   filterSuggestions: true
   suggestionPriority: 5
+  inclusionPriority: 5
 
   completions: {}
 


### PR DESCRIPTION
Make sure this is included when providers with a priority have the exclude lower flag set (to exclude e.g. the default provider). I think suggestions from this provider should be fairly infrequently false positives, comparatively speaking.

Example of this coming up: https://github.com/nwolverson/atom-ide-purescript/issues/42
