### PR TITLE
Provide better initial ordering

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs'
 path = require 'path'
+score = require 'string-score'
 
 module.exports =
   filterSuggestions: true
@@ -26,7 +27,8 @@ module.exports =
   getSuggestions: ({bufferPosition, editor}) ->
     line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
     prefix = line.match(@texPattern)?[1]
-    prefix? && ({text: word, leftLabel: char, replacementPrefix: prefix} for word, char of @completions)
+    if prefix?
+      ({text, leftLabel, replacementPrefix: prefix, score: score(text, prefix)} for text, leftLabel of @completions).sort (c) -> c.score
 
   onDidInsertSuggestion: ({editor, triggerPosition, suggestion}) ->
     word = suggestion.text

--- a/package.json
+++ b/package.json
@@ -16,5 +16,7 @@
       }
     }
   },
-  "dependencies": {}
+  "dependencies": {
+    "string-score": "*"
+  }
 }


### PR DESCRIPTION
fixes #15:
![theta](https://cloud.githubusercontent.com/assets/6735977/20859800/f56d29fe-b969-11e6-8522-b9a4e53cb219.png)

This basically orders the suggestions in a non-fuzzy manner before giving them to the autocomplete-plus fuzzy matcher.

@dmbates, @spencerlyon2, @jmboehm: It'd be nice if some of you could try this before we merge.