### PR TITLE
add option to boost greek characters' priority

### DIFF
--- a/lib/latex-completions.coffee
+++ b/lib/latex-completions.coffee
@@ -23,9 +23,15 @@ module.exports =
       default: '.tex, .latex'
       description: 'Disable completions under these scopes:'
       order: 4
+    boostGreekCharacters:
+      type: 'boolean'
+      default: true
+      description: 'Make common greek characters easier to complete by moving them higher in the list of completions.'
 
   activate: ->
     atom.config.get("latex-completions.enableDefaultCompletions") && provider.load()
+
+    provider.activate()
 
     @subscriptions = new CompositeDisposable
 
@@ -37,3 +43,4 @@ module.exports =
 
   deactivate: ->
     @subscriptions.dispose()
+    provider.deactivate()

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     }
   },
   "dependencies": {
-    "string-score": "*"
+    "fuzzaldrin-plus": "^0.6.0"
   }
 }


### PR DESCRIPTION
This also makes for faster and more robust autocompletions since we're only sorting once now.

If the `Boost Greek Characters` option is set (as is the case by default) it's possible to type most (maybe all) greek characters with a `\` followed by the first char and `tab`, e.g. `\l\tab` for `λ`:

![lambda](https://user-images.githubusercontent.com/6735977/40665238-069a9696-635d-11e8-8c2a-d09d09c87544.png)

 This has the obvious cost of not being able to type `ł` (`\l`) without navigating the autocompletion menu.

Ref https://github.com/JunoLab/Juno.jl/issues/140.